### PR TITLE
Update for issue 13433 (attempt 2)

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2676,7 +2676,7 @@ private immutable long[__traits(allMembers, ClockType).length] _ticksPerSecond;
                 // or worse, but the time is updated much more frequently
                 // than that). In such cases, we'll just use nanosecond
                 // resolution.
-                _ticksPerSecond[MonoTimeImpl!clockArg._clockIdx] = ts.tv_nsec >= 1000 ? 1_000_000_000L
+                _ticksPerSecond[i] = ts.tv_nsec >= 1000 ? 1_000_000_000L
                     : 1_000_000_000L / ts.tv_nsec;
             }
         }


### PR DESCRIPTION
Wow, this was really more complicated than I thought it would be.
1. The saved field must be immutable or pure functions cannot access it
2. A static ctor outside a struct CANNOT set a static immutable field inside a struct.

So I had to do this weird thing where I store it in a static array outside the struct. But it does work (at least for MacOS X).

Note that all this can be undone when the static ctor bug is fixed.
